### PR TITLE
Pin rpmfile and zstandard versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This tool helps identify differences in file sizes between two RPM packages comp
   - Size in Package A
   - Size in Package B
   - Size difference in bytes and percentage
+- Optionally save the table to a CSV file using the `--csv` flag
 
 ## 🧠 Use Case
 
@@ -23,7 +24,7 @@ Use this tool to analyze size regressions or improvements when recompiling the s
 ## 🛠️ Example
 
 ```bash
-python compare_rpm_sizes.py ./package-arm.rpm ./package-riscv.rpm
+python compare_rpm_sizes.py ./package-arm.rpm ./package-riscv.rpm --csv
 ```
 
 ## Requirements

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-rpmfile
-zstandard
+rpmfile==2.1.0
+zstandard==0.23.0


### PR DESCRIPTION
## Summary
- pin rpmfile and zstandard in requirements.txt

## Testing
- `python -m py_compile compare_rpm_sizes.py`
- `pytest -q`
- `python compare_rpm_sizes.py -h` *(fails: ModuleNotFoundError: No module named 'rpmfile')*


------
https://chatgpt.com/codex/tasks/task_e_68569f9008ac83219370682dcb75c4ac