### PR TITLE
Fix absolute path handling in lib normalization

### DIFF
--- a/compare_rpm_sizes.py
+++ b/compare_rpm_sizes.py
@@ -4,19 +4,37 @@ import os
 import rpmfile
 
 
-def normalize_lib_paths(path):
-    """Normalize lib directories so /lib64 and /usr/lib64 map to /lib and
-    /usr/lib respectively. This helps compare 32-bit and 64-bit packages.
+def normalize_lib_paths(path: str) -> str:
+    """Normalize lib directories so ``lib64`` and ``usr/lib64`` map to ``lib``
+    and ``usr/lib`` respectively.
+
+    The function preserves whether the original path was absolute. A leading
+    ``/`` (if present) is removed before applying the replacements and added
+    back to the normalized path when returning.
     """
+
+    # Remember if the path started with a slash and strip it for the
+    # normalization logic.
+    was_absolute = path.startswith("/")
+    if was_absolute:
+        path = path[1:]
+
     replacements = [
-        ("/lib64/", "/lib/"),
-        ("/lib32/", "/lib/"),
-        ("/usr/lib64/", "/usr/lib/"),
-        ("/usr/lib32/", "/usr/lib/"),
+        ("lib64/", "lib/"),
+        ("lib32/", "lib/"),
+        ("usr/lib64/", "usr/lib/"),
+        ("usr/lib32/", "usr/lib/"),
     ]
+
     for old, new in replacements:
         if path.startswith(old):
             path = new + path[len(old):]
+            break
+
+    # Re-apply the leading slash if the original path was absolute.
+    if was_absolute:
+        path = "/" + path
+
     return path
 
 

--- a/test_normalize_lib_paths.py
+++ b/test_normalize_lib_paths.py
@@ -1,0 +1,15 @@
+import pytest
+from compare_rpm_sizes import normalize_lib_paths
+
+@pytest.mark.parametrize(
+    "src,expected",
+    [
+        ("/usr/lib64/lib.so", "/usr/lib/lib.so"),
+        ("/lib32/foo", "/lib/foo"),
+        ("usr/lib64/lib.so", "usr/lib/lib.so"),
+        ("lib64/bar", "lib/bar"),
+        ("/home/user/lib64/file", "/home/user/lib64/file"),
+    ],
+)
+def test_normalize_lib_paths(src, expected):
+    assert normalize_lib_paths(src) == expected


### PR DESCRIPTION
## Summary
- make `normalize_lib_paths` aware of absolute paths
- map lib64/usr/lib64 prefixes after stripping the leading slash
- add a small test suite for the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856a86948748321a625e8a380a9a153