### PR TITLE
Fix path normalization for relative RPM entries

### DIFF
--- a/compare_rpm_sizes.py
+++ b/compare_rpm_sizes.py
@@ -4,19 +4,24 @@ import os
 import rpmfile
 
 
-def normalize_lib_paths(path):
-    """Normalize lib directories so /lib64 and /usr/lib64 map to /lib and
-    /usr/lib respectively. This helps compare 32-bit and 64-bit packages.
+def normalize_lib_paths(path: str) -> str:
+    """Normalize library directory prefixes for RPM paths.
+
+    RPM entries often begin with ``./``. Only those prefixes are handled and no
+    attempt is made to deal with absolute paths.
     """
+
     replacements = [
-        ("/lib64/", "/lib/"),
-        ("/lib32/", "/lib/"),
-        ("/usr/lib64/", "/usr/lib/"),
-        ("/usr/lib32/", "/usr/lib/"),
+        ("./lib64/", "./lib/"),
+        ("./lib32/", "./lib/"),
+        ("./usr/lib64/", "./usr/lib/"),
+        ("./usr/lib32/", "./usr/lib/"),
     ]
+
     for old, new in replacements:
         if path.startswith(old):
-            path = new + path[len(old):]
+            return new + path[len(old):]
+
     return path
 
 

--- a/test_normalize_lib_paths.py
+++ b/test_normalize_lib_paths.py
@@ -1,0 +1,16 @@
+import pytest
+from compare_rpm_sizes import normalize_lib_paths
+
+@pytest.mark.parametrize(
+    "src,expected",
+    [
+        ("./usr/lib64/lib.so", "./usr/lib/lib.so"),
+        ("./usr/lib32/libX.so", "./usr/lib/libX.so"),
+        ("./lib64/file", "./lib/file"),
+        ("./lib32/foo/bar", "./lib/foo/bar"),
+        ("/home/user/lib64/file", "/home/user/lib64/file"),
+        ("/usr/lib64/lib.so", "/usr/lib64/lib.so"),
+    ],
+)
+def test_normalize_lib_paths(src, expected):
+    assert normalize_lib_paths(src) == expected


### PR DESCRIPTION
## Summary
- simplify normalize_lib_paths to only handle `./`-prefixed entries
- update unit tests for new behavior

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856a86948748321a625e8a380a9a153