### PR TITLE
Add more comparison options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,15 @@ This tool helps identify differences in file sizes between two RPM packages comp
 - Extracts and lists file sizes from each package.
 - Outputs a comparison table with:
   - File paths
-  - Size in Package A
-  - Size in Package B
-  - Size difference in bytes and percentage
-  - File type detected via libmagic
+  - Size in Package A (MB)
+  - Size in Package B (MB)
+  - Size difference in MB and percentage
+  - File type detected via libmagic for each package
 - Optionally save the table to a CSV file using the `--csv` flag
 - Use `--64` to normalize `/lib*` and `/usr/lib*` paths when comparing 32-bit and 64-bit packages
+- Hide files with the same size using `--hide-equal`
+- Remove version suffixes from `.so` files with `--ignore-versions`
+- Skip symbolic links with `--ignore-links`
 
 ## 🧠 Use Case
 

--- a/compare_rpm_sizes.py
+++ b/compare_rpm_sizes.py
@@ -1,6 +1,7 @@
 import argparse
 import csv
 import os
+import re
 import rpmfile
 import magic
 
@@ -36,30 +37,62 @@ def normalize_lib_paths(path: str) -> str:
     return path
 
 
-def extract_info(path, normalize=None):
+def strip_version(path: str) -> str:
+    """Remove trailing numeric version components from shared library names."""
+    return re.sub(r"(\.so)(?:\.[0-9]+)+$", r"\1", path)
+
+
+def extract_info(path, normalize=None, ignore_links=False, ignore_versions=False):
     """Return a mapping of file path to (size, type)."""
     info = {}
     with rpmfile.open(path) as rpm:
+        link_map = set()
+        if ignore_links:
+            modes = rpm.headers.get("filemodes") or []
+            names = rpm.headers.get("filenames") or []
+            names = [n.decode() if isinstance(n, bytes) else n for n in names]
+            for name, mode in zip(names, modes):
+                if int(mode) & 0o170000 == 0o120000:
+                    link_map.add("./" + name if not name.startswith("./") else name)
         for member in rpm.getmembers():
-            # Skip directory entries. `isdir` can be a property or a method
+            name = member.name
+            if ignore_links and name in link_map:
+                continue
             is_dir = getattr(member, "isdir", False)
             if callable(is_dir):
                 is_dir = is_dir()
             if is_dir:
                 continue
-            name = member.name
             if normalize:
                 name = normalize(name)
+            if ignore_versions:
+                name = strip_version(name)
             with rpm.extractfile(member) as f:
                 header = f.read(2048)
             info[name] = (member.size, detect_file_type(header))
     return info
 
 
-def compare_rpms(path_a, path_b, csv_path=None, normalize=False):
+def to_mb(size: int) -> float:
+    return size / (1024 * 1024)
+
+
+def compare_rpms(
+    path_a,
+    path_b,
+    csv_path=None,
+    normalize=False,
+    hide_equal=False,
+    ignore_versions=False,
+    ignore_links=False,
+):
     norm = normalize_lib_paths if normalize else None
-    info_a = extract_info(path_a, normalize=norm)
-    info_b = extract_info(path_b, normalize=norm)
+    info_a = extract_info(
+        path_a, normalize=norm, ignore_links=ignore_links, ignore_versions=ignore_versions
+    )
+    info_b = extract_info(
+        path_b, normalize=norm, ignore_links=ignore_links, ignore_versions=ignore_versions
+    )
     files = sorted(set(info_a) | set(info_b))
 
     csv_file = None
@@ -67,9 +100,20 @@ def compare_rpms(path_a, path_b, csv_path=None, normalize=False):
     if csv_path:
         csv_file = open(csv_path, "w", newline="")
         writer = csv.writer(csv_file)
-        writer.writerow(["File", "Size A (bytes)", "Size B (bytes)", "Diff %", "Type"])
+        writer.writerow([
+            "File",
+            "Size A (MB)",
+            "Size B (MB)",
+            "Diff (MB)",
+            "Diff %",
+            "Type A",
+            "Type B",
+        ])
 
-    print(f"{'File':<50} {'Size A (bytes)':>15} {'Size B (bytes)':>15} {'Diff %':>8} {'Type':<10}")
+    print(
+        f"{'File':<50} {'Size A (MB)':>12} {'Size B (MB)':>12} {'Diff (MB)':>12} {'Diff %':>8} {'Type A':<10} {'Type B':<10}"
+    )
+    total_a = total_b = 0
     for name in files:
         info_a_entry = info_a.get(name)
         info_b_entry = info_b.get(name)
@@ -77,11 +121,48 @@ def compare_rpms(path_a, path_b, csv_path=None, normalize=False):
             continue
         size_a, type_a = info_a_entry
         size_b, type_b = info_b_entry
+        if hide_equal and size_a == size_b:
+            continue
+        total_a += size_a
+        total_b += size_b
+        diff_mb = to_mb(size_b - size_a)
         diff_percent = ((size_b - size_a) * 100.0 / size_a) if size_a else float('inf')
-        ftype = type_a if type_a == type_b else f"{type_a}/{type_b}"
-        print(f"{name:<50} {size_a:>15} {size_b:>15} {diff_percent:>7.2f}% {ftype:<10}")
+        sign = '+' if diff_mb > 0 else ''
+        ftype_a = type_a
+        ftype_b = type_b
+        print(
+            f"{name:<50} {to_mb(size_a):>12.2f} {to_mb(size_b):>12.2f} {sign}{diff_mb:>11.2f} {sign}{diff_percent:>7.2f}% {ftype_a:<10} {ftype_b:<10}"
+        )
         if writer:
-            writer.writerow([name, size_a, size_b, f"{diff_percent:.2f}%", ftype])
+            writer.writerow(
+                [
+                    name,
+                    f"{to_mb(size_a):.2f}",
+                    f"{to_mb(size_b):.2f}",
+                    f"{sign}{diff_mb:.2f}",
+                    f"{sign}{diff_percent:.2f}%",
+                    ftype_a,
+                    ftype_b,
+                ]
+            )
+
+    diff_total_mb = to_mb(total_b - total_a)
+    sign_total = '+' if diff_total_mb > 0 else ''
+    print(
+        f"{'TOTAL':<50} {to_mb(total_a):>12.2f} {to_mb(total_b):>12.2f} {sign_total}{diff_total_mb:>11.2f} {sign_total}{((total_b - total_a) * 100.0 / total_a) if total_a else float('inf'):>7.2f}%"
+    )
+    if writer:
+        writer.writerow(
+            [
+                'TOTAL',
+                f"{to_mb(total_a):.2f}",
+                f"{to_mb(total_b):.2f}",
+                f"{sign_total}{diff_total_mb:.2f}",
+                f"{sign_total}{((total_b - total_a) * 100.0 / total_a) if total_a else float('inf'):.2f}%",
+                '',
+                '',
+            ]
+        )
 
     if csv_file:
         csv_file.close()
@@ -96,13 +177,24 @@ def main():
                         help='Save results to CSV. If FILE not provided, uses <rpm_a> name with .csv')
     parser.add_argument('--64', dest='arch64', action='store_true',
                         help='Normalize lib paths for comparing 32-bit vs 64-bit packages')
+    parser.add_argument('--hide-equal', action='store_true', help='Hide files with identical sizes')
+    parser.add_argument('--ignore-versions', action='store_true', help='Ignore version suffix in .so filenames')
+    parser.add_argument('--ignore-links', action='store_true', help='Ignore symbolic links in RPMs')
     args = parser.parse_args()
 
     csv_path = None
     if args.csv is not None:
         csv_path = args.csv or os.path.splitext(args.rpm_a)[0] + '.csv'
 
-    compare_rpms(args.rpm_a, args.rpm_b, csv_path, normalize=args.arch64)
+    compare_rpms(
+        args.rpm_a,
+        args.rpm_b,
+        csv_path,
+        normalize=args.arch64,
+        hide_equal=args.hide_equal,
+        ignore_versions=args.ignore_versions,
+        ignore_links=args.ignore_links,
+    )
 
 
 if __name__ == '__main__':

--- a/test_strip_version.py
+++ b/test_strip_version.py
@@ -1,0 +1,14 @@
+import pytest
+from compare_rpm_sizes import strip_version
+
+@pytest.mark.parametrize(
+    "src,expected",
+    [
+        ("libfoo.so.1", "libfoo.so"),
+        ("libfoo.so.1.2.3", "libfoo.so"),
+        ("libfoo.so", "libfoo.so"),
+        ("/usr/lib/libfoo.so.1.0", "/usr/lib/libfoo.so"),
+    ],
+)
+def test_strip_version(src, expected):
+    assert strip_version(src) == expected


### PR DESCRIPTION
## Summary
- compare shared libraries without version numbers via regex
- support MB size output
- skip symbolic links
- filter out unchanged files
- append diff values in MB and show totals
- add CLI options for new behavior
- cover strip_version with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68571609acdc8321967b7b93bfb2d614