### PR TITLE
Enhance CSV export quoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This tool helps identify differences in file sizes between two RPM packages comp
   - Size difference in KB and percentage
   - File type detected via libmagic for each package
 - Optionally save the table to a CSV file using the `--csv` flag
-  (semicolon `;` delimited)
+  (semicolon `;` delimited, all fields quoted)
 - Use `--64` to normalize `/lib*` and `/usr/lib*` paths when comparing 32-bit and 64-bit packages
 - Hide files with the same size using `--hide-equal`
 - Remove version suffixes from `.so` files with `--ignore-versions`

--- a/compare_rpm_sizes.py
+++ b/compare_rpm_sizes.py
@@ -100,7 +100,7 @@ def compare_rpms(
     writer = None
     if csv_path:
         csv_file = open(csv_path, "w", newline="")
-        writer = csv.writer(csv_file, delimiter=';')
+        writer = csv.writer(csv_file, delimiter=';', quoting=csv.QUOTE_ALL)
         writer.writerow([
             "File",
             "Size A (KB)",

--- a/test_csv_quoting.py
+++ b/test_csv_quoting.py
@@ -1,0 +1,19 @@
+import compare_rpm_sizes as cmp
+
+
+def dummy_extract_info(path, normalize=None, ignore_links=False, ignore_versions=False):
+    if path == 'a':
+        return {'./file': (100, 'text')}
+    else:
+        return {'./file': (110, 'text')}
+
+
+def test_csv_all_fields_quoted(tmp_path, monkeypatch):
+    out = tmp_path / "report.csv"
+    monkeypatch.setattr(cmp, 'extract_info', dummy_extract_info)
+    cmp.compare_rpms('a', 'b', csv_path=str(out))
+    with open(out, newline='') as f:
+        for row in f:
+            fields = row.strip().split(';')
+            for field in fields:
+                assert field.startswith('"') and field.endswith('"')


### PR DESCRIPTION
## Summary
- quote all CSV fields by using `csv.QUOTE_ALL`
- document quoting behaviour in README
- test that CSV report always quotes each column

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: failed to find libmagic)*

------
https://chatgpt.com/codex/tasks/task_e_68573993f3688321a25dd23fa4c0c033